### PR TITLE
Fix menu visibility in browsers with bouncing effect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,11 @@ const setupMenu = () => {
   window.addEventListener("scroll", () => {
     const currentScroll = window.scrollY;
 
-    if (previousScroll < currentScroll) {
+    const isWithinPageBounds =
+      currentScroll > 0 &&
+      currentScroll < document.body.scrollHeight - window.innerHeight;
+
+    if (isWithinPageBounds && previousScroll < currentScroll) {
       header.style.top = "-100px";
     } else {
       header.style.top = "0px";


### PR DESCRIPTION
Browsers with a bounce effect (like Chrome in iOS)
report a negative scrolling value while bouncing
at the top of the page. The same happens when it
bounces down at the bottom (it reports a scroll
value higher than the whole page).

The code detects when the scroll is out of bounds
and prevents it from hiding the menu in that case.